### PR TITLE
Unix support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ types.ppu
 *.ppu
 underworld-rc.res
 underworld.or
+
+# ignore executalbe on unix
+underworld

--- a/canvas.pas
+++ b/canvas.pas
@@ -2,10 +2,12 @@ unit Canvas;
 
 interface
 	uses
-		outputcolor,
-		{$IFDEF WINDOWS}
-		windows;
-		{$ENDIF}
+	{$IFDEF WINDOWS}
+		windows,
+	{$ELSE}
+		crt,
+	{$ENDIF}
+		outputcolor;
 	const
 		ConsoleWidth = 79;
 		ConsoleHeight = 24;
@@ -44,37 +46,70 @@ interface
 	
 implementation
 	procedure GotoXY(x, y: Integer);
+	{$IFDEF WINDOWS}
 	var
 		pos: TCoord;
+	{$ENDIF}
 	begin
+		{$IFDEF WINDOWS}
 		pos.x := x;
 		pos.y := y;
 		SetConsoleCursorPosition(GetStdHandle(STD_OUTPUT_HANDLE), pos);
+		{$ELSE}
+		crt.GotoXY(x+1,y+1);
+		{$ENDIF}
 	end;
 	
 	procedure GetXY(var x: Integer; var y: Integer);
+	{$IFDEF WINDOWS}
 	var
 		csbi: CONSOLE_SCREEN_BUFFER_INFO;
+	{$ENDIF}
 	begin
+	{$IFDEF WINDOWS}
 		GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), csbi);
 		x := csbi.dwCursorPosition.x;
 		y := csbi.dwCursorPosition.y;
+	{$ELSE}
+		x := WhereX()-1;
+		y := WhereY()-1;
+	{$ENDIF}
 	end;
 	
 	procedure LineChar(x, y: Integer; length: Integer; ch: Char);
 	var
+	{$IFDEF WINDOWS}
 		pos: TCoord;
 		lUnused: LongWord;
+	{$ELSE}
+		origX: Integer;
+		origY: Integer;
+		I : Integer;
+	{$ENDIF}
 	begin
+		{$IFDEF WINDOWS}
 		pos.x := x;
 		pos.y := y;
 		FillConsoleOutputAttribute(GetStdHandle(STD_OUTPUT_HANDLE), 0, length, pos, lUnused);
 		FillConsoleOutputCharacter(GetStdHandle(STD_OUTPUT_HANDLE), ch, length, pos, lUnused);
+		{$ELSE}
+		GetXY(origX, origY);
+		GotoXY(x, y);
+		for I := 1 to length do
+		begin
+			Write(ch);
+		end;
+		GotoXY(origX, origY);
+		{$ENDIF}
 	end;
 	
 	procedure CanvasClear();
 	begin
+		{$IFDEF WINDOWS}
 		LineChar(0, 0, 2000, ' ');
+		{$ELSE}
+		ClrScr();
+		{$ENDIF}
 		GotoXY(0, 0);
 	end;
 	
@@ -255,9 +290,10 @@ implementation
 	procedure CanvasForseFlush(); // Erase full screen except event's text
 	var
 		I: Integer;
-		pos: TCoord;
+		x: Integer;
+		y: Integer;
 	begin
-		GetXY(pos.x, pos.y);
+		GetXY(x, y);
 		
 		LineChar(0, ConsoleHeight, 50, ' ');
 			
@@ -298,6 +334,6 @@ implementation
 		for I := 1 to 10 do
 			LineChar(51, I, 28, ' ');
 			
-		GotoXY(pos.x, pos.y);
+		GotoXY(x, y);
 	end;
 end.

--- a/outputcolor.pas
+++ b/outputcolor.pas
@@ -2,9 +2,11 @@ unit OutputColor;
 
 interface
 	uses
-		{$IFDEF WINDOWS}
+	{$IFDEF WINDOWS}
 		windows;
-		{$ENDIF}
+	{$ELSE}
+		crt;
+	{$ENDIF}
 	
 	const
 		ColorDefault = 'LightGray';
@@ -42,6 +44,8 @@ implementation
 	begin
 		{$IFDEF WINDOWS}
 		SetConsoleTextAttribute(GetStdHandle(STD_OUTPUT_HANDLE), color);
+		{$ELSE}
+		crt.TextColor(color);
 		{$ENDIF}
 	end;
 	
@@ -49,6 +53,8 @@ implementation
 	begin
 		{$IFDEF WINDOWS}
 		SetConsoleTextAttribute(GetStdHandle(STD_OUTPUT_HANDLE), BACKGROUND_RED or BACKGROUND_GREEN or BACKGROUND_INTENSITY);
+		{$ELSE}
+		
 		{$ENDIF}
 	end;
 	

--- a/storyparser.pas
+++ b/storyparser.pas
@@ -570,7 +570,7 @@ implementation
 		token: String;
 		folderPath: String;
 	begin
-		folderPath := './Story/';
+		folderPath := './story/';
 		fileName := fileName + '.spt';
 		Assign(text, folderPath + fileName);
 		Reset(text);
@@ -591,7 +591,7 @@ implementation
 		folderPath: String;
 		stories: TStories;
 	begin
-		folderPath := './Story/';
+		folderPath := './story/';
 		Assign(text, folderPath + fileName);
 		Reset(text);
 		ReadToken(text, token);

--- a/types.pas
+++ b/types.pas
@@ -8,7 +8,7 @@ interface
 			text: String;
 			color: String;
 		end;
-		
+	
 		TMultiLineColorText = array of TColorString;
 		
 		TStat = record

--- a/underworld.pas
+++ b/underworld.pas
@@ -14,6 +14,7 @@ uses
 	screens,
 	{$IFDEF UNIX}
 	unix,
+	crt,
 	{$ENDIF}
 	types;
 
@@ -62,7 +63,7 @@ begin
 	//Allows to run executable directly from file manager.
 	if isatty(1) = 0 then
 	begin
-		Shell(Concat('xterm -geometry 100x26 -e ', ParamStr(0)));
+		fpSystem(Concat('xterm -geometry 100x26 -e ', ParamStr(0)));
 		Exit;
 	end;
 	{$ENDIF}
@@ -74,6 +75,6 @@ begin
 	until not isPlaying;
 	{$IFDEF UNIX}
 	//Restore terminal settings
-	Shell('echo -ne "\033c"');
+	fpSystem('tput rs1');
 	{$ENDIF}
 end.


### PR DESCRIPTION
Tested on Debian 8, FreeBSD 10 and OS X Yosemite with free pascal.
Known issues: 
- Ctrl+C does not work.
- Terminal must be enough size to hold output.
- UTF-8 support must be enabled by user on FreeBSD.
- Has errors when running on OS X by double click from file manager.
