### PR TITLE
Implementation using ncrt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ types.ppu
 *.ppu
 underworld-rc.res
 underworld.or
+
+# ignore executalbe on unix
+underworld

--- a/canvas.pas
+++ b/canvas.pas
@@ -2,10 +2,12 @@ unit Canvas;
 
 interface
 	uses
-		outputcolor,
-		{$IFDEF WINDOWS}
-		windows;
-		{$ENDIF}
+	{$IFDEF WINDOWS}
+		windows,
+	{$ELSE}
+		crt,
+	{$ENDIF}
+		outputcolor;
 	const
 		ConsoleWidth = 79;
 		ConsoleHeight = 24;
@@ -44,37 +46,70 @@ interface
 	
 implementation
 	procedure GotoXY(x, y: Integer);
+	{$IFDEF WINDOWS}
 	var
 		pos: TCoord;
+	{$ENDIF}
 	begin
+		{$IFDEF WINDOWS}
 		pos.x := x;
 		pos.y := y;
 		SetConsoleCursorPosition(GetStdHandle(STD_OUTPUT_HANDLE), pos);
+		{$ELSE}
+		crt.GotoXY(x+1,y+1);
+		{$ENDIF}
 	end;
 	
 	procedure GetXY(var x: Integer; var y: Integer);
+	{$IFDEF WINDOWS}
 	var
 		csbi: CONSOLE_SCREEN_BUFFER_INFO;
+	{$ENDIF}
 	begin
+	{$IFDEF WINDOWS}
 		GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), csbi);
 		x := csbi.dwCursorPosition.x;
 		y := csbi.dwCursorPosition.y;
+	{$ELSE}
+		x := WhereX()-1;
+		y := WhereY()-1;
+	{$ENDIF}
 	end;
 	
 	procedure LineChar(x, y: Integer; length: Integer; ch: Char);
 	var
+	{$IFDEF WINDOWS}
 		pos: TCoord;
 		lUnused: LongWord;
+	{$ELSE}
+		origX: Integer;
+		origY: Integer;
+		I : Integer;
+	{$ENDIF}
 	begin
+		{$IFDEF WINDOWS}
 		pos.x := x;
 		pos.y := y;
 		FillConsoleOutputAttribute(GetStdHandle(STD_OUTPUT_HANDLE), 0, length, pos, lUnused);
 		FillConsoleOutputCharacter(GetStdHandle(STD_OUTPUT_HANDLE), ch, length, pos, lUnused);
+		{$ELSE}
+		GetXY(origX, origY);
+		GotoXY(x, y);
+		for I := 1 to length do
+		begin
+			Write(ch);
+		end;
+		GotoXY(origX, origY);
+		{$ENDIF}
 	end;
 	
 	procedure CanvasClear();
 	begin
+		{$IFDEF WINDOWS}
 		LineChar(0, 0, 2000, ' ');
+		{$ELSE}
+		ClrScr();
+		{$ENDIF}
 		GotoXY(0, 0);
 	end;
 	
@@ -255,9 +290,10 @@ implementation
 	procedure CanvasForseFlush(); // Erase full screen except event's text
 	var
 		I: Integer;
-		pos: TCoord;
+		x: Integer;
+		y: Integer;
 	begin
-		GetXY(pos.x, pos.y);
+		GetXY(x, y);
 		
 		LineChar(0, ConsoleHeight, 50, ' ');
 			
@@ -298,6 +334,6 @@ implementation
 		for I := 1 to 10 do
 			LineChar(51, I, 28, ' ');
 			
-		GotoXY(pos.x, pos.y);
+		GotoXY(x, y);
 	end;
 end.

--- a/canvas.pas
+++ b/canvas.pas
@@ -5,7 +5,8 @@ interface
 	{$IFDEF WINDOWS}
 		windows,
 	{$ELSE}
-		crt,
+		setlocale,
+		ncrt,
 	{$ENDIF}
 		outputcolor;
 	const
@@ -56,7 +57,7 @@ implementation
 		pos.y := y;
 		SetConsoleCursorPosition(GetStdHandle(STD_OUTPUT_HANDLE), pos);
 		{$ELSE}
-		crt.GotoXY(x+1,y+1);
+		ncrt.GotoXY(x+1,y+1);
 		{$ENDIF}
 	end;
 	

--- a/outputcolor.pas
+++ b/outputcolor.pas
@@ -41,6 +41,17 @@ interface
 	procedure ColorWrite(normalText: Real; chosenColor: String; newLine: Integer);
 	
 implementation	
+	procedure MyWriteLn(s : String);
+	begin
+		Write(s);
+		GotoXY(1, WhereY()+1);
+	end;
+	
+	procedure MyWriteLn();
+	begin
+		GotoXY(1, WhereY()+1);
+	end;
+
 	procedure TextColor(color: Integer);
 	begin
 		{$IFDEF WINDOWS}
@@ -62,7 +73,7 @@ implementation
 	procedure ColorWrite(normalText: String);	
 	begin
 		TextColor(7);
-		WriteLn(normalText);
+		MyWriteLn(normalText);
 	end;
 	
 	procedure ColorWrite(normalText: String; chosenColor: String);
@@ -107,7 +118,7 @@ implementation
 			while UTF8Decode(normalText)[I] <> ' ' do
 				I := I - 1;
 
-			Writeln(String(UTF8Encode(Copy(UTF8Decode(normalText), 0, I))));
+			MyWriteln(String(UTF8Encode(Copy(UTF8Decode(normalText), 0, I))));
 			Exit(PrintLargeText(UTF8Encode(Copy(UTF8Decode(normalText), I + 1, Length(UTF8Decode(normalText)) - I)), lineSize) + 1);
 			
 		end;
@@ -142,7 +153,7 @@ implementation
 		TextColor(15);
 		for newLineCounter := 1 to newLine do 
 		begin
-			WriteLn();
+			MyWriteLn();
 		end;
 	end;
 	
@@ -175,7 +186,7 @@ implementation
 		TextColor(15);
 		for newLineCounter := 1 to newLine do 
 		begin
-			WriteLn();
+			MyWriteLn();
 		end;
 	end;
 	
@@ -209,7 +220,7 @@ implementation
 		TextColor(15);
 		for newLineCounter := 1 to newLine do 
 		begin
-			WriteLn();
+			MyWriteLn();
 		end;
 	end;
 	
@@ -268,7 +279,7 @@ implementation
 		TextColor(15);
 		for newLineCounter := 1 to newLine do 
 		begin
-			WriteLn();
+			MyWriteLn();
 		end;
 	end;
 	
@@ -327,7 +338,7 @@ implementation
 		TextColor(15);
 		for newLineCounter := 1 to newLine do 
 		begin
-			WriteLn();
+			MyWriteLn();
 		end;
 	end;
 end.

--- a/outputcolor.pas
+++ b/outputcolor.pas
@@ -5,7 +5,8 @@ interface
 	{$IFDEF WINDOWS}
 		windows;
 	{$ELSE}
-		crt;
+		setlocale,
+		ncrt;
 	{$ENDIF}
 	
 	const
@@ -45,7 +46,7 @@ implementation
 		{$IFDEF WINDOWS}
 		SetConsoleTextAttribute(GetStdHandle(STD_OUTPUT_HANDLE), color);
 		{$ELSE}
-		crt.TextColor(color);
+		ncrt.TextColor(color);
 		{$ENDIF}
 	end;
 	

--- a/outputcolor.pas
+++ b/outputcolor.pas
@@ -2,9 +2,11 @@ unit OutputColor;
 
 interface
 	uses
-		{$IFDEF WINDOWS}
+	{$IFDEF WINDOWS}
 		windows;
-		{$ENDIF}
+	{$ELSE}
+		crt;
+	{$ENDIF}
 	
 	const
 		ColorDefault = 'LightGray';
@@ -42,6 +44,8 @@ implementation
 	begin
 		{$IFDEF WINDOWS}
 		SetConsoleTextAttribute(GetStdHandle(STD_OUTPUT_HANDLE), color);
+		{$ELSE}
+		crt.TextColor(color);
 		{$ENDIF}
 	end;
 	
@@ -49,6 +53,8 @@ implementation
 	begin
 		{$IFDEF WINDOWS}
 		SetConsoleTextAttribute(GetStdHandle(STD_OUTPUT_HANDLE), BACKGROUND_RED or BACKGROUND_GREEN or BACKGROUND_INTENSITY);
+		{$ELSE}
+		
 		{$ENDIF}
 	end;
 	

--- a/outputcolor.pas
+++ b/outputcolor.pas
@@ -43,13 +43,21 @@ interface
 implementation	
 	procedure MyWriteLn(s : String);
 	begin
+	{$IFDEF WINDOWS}
+		WriteLn(s);
+	{$ELSE}
 		Write(s);
 		GotoXY(1, WhereY()+1);
+	{$ENDIF}
 	end;
 	
 	procedure MyWriteLn();
 	begin
+	{$IFDEF WINDOWS}
+		WriteLn();
+	{$ELSE}
 		GotoXY(1, WhereY()+1);
+	{$ENDIF}
 	end;
 
 	procedure TextColor(color: Integer);

--- a/setlocale.pas
+++ b/setlocale.pas
@@ -1,0 +1,14 @@
+unit setlocale;
+
+interface
+
+procedure setlocale(cat : integer; p : pchar); cdecl; external name 'setlocale';
+
+const
+	LC_ALL = 6;
+
+implementation
+	
+begin
+	setlocale(LC_ALL, PChar(''));
+end.

--- a/storyparser.pas
+++ b/storyparser.pas
@@ -570,7 +570,7 @@ implementation
 		token: String;
 		folderPath: String;
 	begin
-		folderPath := './Story/';
+		folderPath := './story/';
 		fileName := fileName + '.spt';
 		Assign(text, folderPath + fileName);
 		Reset(text);
@@ -591,7 +591,7 @@ implementation
 		folderPath: String;
 		stories: TStories;
 	begin
-		folderPath := './Story/';
+		folderPath := './story/';
 		Assign(text, folderPath + fileName);
 		Reset(text);
 		ReadToken(text, token);

--- a/types.pas
+++ b/types.pas
@@ -8,7 +8,7 @@ interface
 			text: String;
 			color: String;
 		end;
-		
+	
 		TMultiLineColorText = array of TColorString;
 		
 		TStat = record

--- a/underworld-xterm.sh
+++ b/underworld-xterm.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+xterm -fa 'Monospace' -fs 16 -geometry 80x26 -e ./underworld

--- a/underworld.pas
+++ b/underworld.pas
@@ -13,8 +13,9 @@ uses
 	outputcolor,
 	screens,
 	{$IFDEF UNIX}
+	setlocale,
 	unix,
-	crt,
+	ncrt,
 	{$ENDIF}
 	types;
 

--- a/underworld.pas
+++ b/underworld.pas
@@ -14,6 +14,7 @@ uses
 	screens,
 	{$IFDEF UNIX}
 	unix,
+	crt,
 	{$ENDIF}
 	types;
 
@@ -62,7 +63,7 @@ begin
 	//Allows to run executable directly from file manager.
 	if isatty(1) = 0 then
 	begin
-		Shell(Concat('xterm -geometry 100x26 -e ', ParamStr(0)));
+		fpSystem(Concat('xterm -geometry 100x26 -e ', ParamStr(0)));
 		Exit;
 	end;
 	{$ENDIF}
@@ -74,6 +75,6 @@ begin
 	until not isPlaying;
 	{$IFDEF UNIX}
 	//Restore terminal settings
-	Shell('echo -ne "\033c"');
+	fpSystem('tput rs1');
 	{$ENDIF}
 end.

--- a/underworld.pas
+++ b/underworld.pas
@@ -49,25 +49,12 @@ begin
 	DisposeAll(locations, status);
 end;
 
-{$IFDEF UNIX}
-function isatty(fd : Integer) : Integer; CDECL; external name 'isatty';
-{$ENDIF}
-
 var
 	isPlaying: Boolean;
 	status: TStatus;	
 	locations: TLocations;
 	
 begin
-	{$IFDEF UNIX and $IFNDEF DARWIN}
-	//If program is not running in terminal, run it in xterm.
-	//Allows to run executable directly from file manager.
-	if isatty(1) = 0 then
-	begin
-		fpSystem(Concat('xterm -geometry 100x26 -e ', ParamStr(0)));
-		Exit;
-	end;
-	{$ENDIF}
 	repeat
 		isPlaying := false;
 		Initialize(locations, status);	


### PR DESCRIPTION
Seems like it does not have problems with layout of utf-8 strings. But it requires ncrt unit and depends on ncurses library. 
For now tested only on Debian 8.

ncrt as well as bindings to ncurses should be included in the latest fpc versions. If not, can be found here: https://github.com/graemeg/freepascal/tree/master/packages/ncurses/src
